### PR TITLE
README: fix link to OpenWrt package README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ root@OpenWrt:~# /etc/init.d/https-dns-proxy enable
 root@OpenWrt:~# /etc/init.d/https-dns-proxy start
 ```
 
-OpenWrt's init script automatically updates the `dnsmasq` config to include only DoH servers on its start and restores old settings on stop. Additional information on OpenWrt-specific configuration is available at the [README](https://github.com/openwrt/packages/blob/master/net/https-dns-proxy/files/README.md).
+OpenWrt's init script automatically updates the `dnsmasq` config to include only DoH servers on its start and restores old settings on stop. Additional information on OpenWrt-specific configuration is available at the [README](https://docs.openwrt.melmac.net/https-dns-proxy/).
 
 If you are using any other resolver on your router you will need to manually replace any previously used servers with entries like:
 


### PR DESCRIPTION
Mostly because the screenshots cannot be hosted in OpenWrt packages repo I've moved all the READMEs for the packages I maintain to a separate GitHub repo/web.